### PR TITLE
Add autofill button to link modal

### DIFF
--- a/ui/src/components/Editor/ToolBars/link.tsx
+++ b/ui/src/components/Editor/ToolBars/link.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next';
 
 import ToolItem from '../toolItem';
 import { IEditorContext } from '../types';
+import { loggedUserInfoStore } from '@/stores';
 
 let context: IEditorContext;
 const Link = () => {
@@ -32,6 +33,7 @@ const Link = () => {
     keyMap: ['Ctrl-l'],
     tip: `${t('link.text')} (Ctrl+l)`,
   };
+  const { user } = loggedUserInfoStore();
   const [visible, setVisible] = useState(false);
   const [link, setLink] = useState({
     value: 'https://',
@@ -87,6 +89,10 @@ const Link = () => {
     editor.focus();
   };
 
+  const handleFillUserInfo = () => {
+    setName({ ...name, value: `${user.display_name} (${user.username})` });
+  };
+
   return (
     <>
       <ToolItem {...item} onClick={addLink} />
@@ -124,6 +130,9 @@ const Link = () => {
                 onChange={(e) => setName({ ...name, value: e.target.value })}
                 isInvalid={name.isInvalid}
               />
+              <Button variant="link" onClick={handleFillUserInfo}>
+                {t('link.fill_user_info')}
+              </Button>
             </Form.Group>
           </Form>
         </Modal.Body>


### PR DESCRIPTION
Add a button to quickly fill in the user's name and email in the link modal.

* Import `loggedUserInfoStore` to access the logged-in user's information.
* Add a new function `handleFillUserInfo` to set the name input field with the user's display name and username.
* Add a new button in the modal to trigger the `handleFillUserInfo` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lxlonion/answer/pull/1?shareId=213bbb4e-6685-4b20-b376-346e4ec970c3).